### PR TITLE
SearchRest - request with both types and indexes not setting path

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRest.java
@@ -40,7 +40,7 @@ public class SearchRest {
             String indices = Joiner.on(',').skipNulls().join(urlEncodeAll(request.indices()));
             if (request.types() == null || request.types().length == 0) {
                 url = url.path(indices, "_search");
-            } else if (request.types() == null || request.types().length == 0) {
+            } else {
                 String types = Joiner.on(',').skipNulls().join(urlEncodeAll(request.types()));
                 url = url.path(indices, types, "_search");
             }


### PR DESCRIPTION
SearchRest - request with both types and indexes not setting path
